### PR TITLE
Bump version to 0.2.1 to release the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [workspace.package]
 # Use a single version for all workspace members
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 homepage = "https://github.com/aya-metrics-rs/aya-metrics"
 repository = "https://github.com/aya-metrics-rs/aya-metrics"


### PR DESCRIPTION
Bump version to 0.2.1 to release the crate with the change https://github.com/aya-metrics-rs/aya-metrics/commit/eebbb562186527a61c7abd9d5c87140c390a75e2